### PR TITLE
fix: update gunicorn start command to bind 0.0.0.0:$PORT for Render

### DIFF
--- a/.github/workflows/render.yaml
+++ b/.github/workflows/render.yaml
@@ -3,4 +3,4 @@ services:
     name: shopnow
     env: python
     buildCommand: "./build.sh"
-    startCommand: "gunicorn shopnow.wsgi:application"
+    startCommand: "startCommand: gunicorn shopnow.wsgi --bind 0.0.0.0:$PORT"


### PR DESCRIPTION
The app deployed but gunicorn isn't binding to the right port. Render dynamically assigns a port via the $PORT environment variable.