### PR TITLE
fix: Normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+*.py text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.js text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.txt text eol=lf
+*.md text eol=lf


### PR DESCRIPTION
- Added .gitattributes
- Configured common project files to use LF line endings
- Helps prevent unnecessary LF ↔ CRLF changes in Git status
- Project was created/edited on Windows
- Then opened/edited on Ubuntu
- Git line-ending setting is not configured
- VS Code auto-converted line endings
- Project is inside a shared/mounted drive

- **No application logic was changed**